### PR TITLE
[AB][00000] Disallow leading newlines

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -4,6 +4,8 @@ module.exports = {
     'comma-dangle': [2, 'never'],
     // require function expressions to have a name
     'func-names': 0,
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1, maxBOF: 0 }],
     // require or disallow use of semicolons instead of ASI
     'semi': [2, 'never'],
     // require or disallow space before function opening parenthesis


### PR DESCRIPTION
Disallows empty lines at the beginning of files.

Note: the only actual change is the `maxBOF: 0`, as the rest matches the current config inherited from `airbnb`.