### PR TITLE
adding extra missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/eslint-config-rentpath",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "RentPath’s extensible shared config for [ESLint](http://eslint.org/)",
   "main": "index.js",
   "repository": {
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-jsx-a11y": "^6.0.2",

--- a/rules/react.js
+++ b/rules/react.js
@@ -12,7 +12,6 @@ module.exports = {
     'react/no-array-index-key': 0,
     // allow string set to prop, overkill
     'react/style-prop-object': 0,
-    // allow class methods that don't utilize 'this'
     // enforces 3 props per line
     'react/jsx-max-props-per-line': [1, { maximum: 3 }],
     // enforces proper names for jsx components

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,14 +1,6 @@
 module.exports = {
   rules: {
-    // enforce a new line after any const or let if func / if follows
-    'padding-line-between-statements': ['error',
-      {
-        'blankLine': 'always',
-        'prev': ['const', 'let'],
-        'next': ['block-like', 'function', 'if']
-      },
-    ],
-    // allow things like __DEV__
+    // allow class methods that don't utilize 'this'
     'class-methods-use-this': 0,
     // require trailing comma in multilines
     'comma-dangle': [2, 'always-multiline'],
@@ -39,9 +31,18 @@ module.exports = {
       'maxEOF': 1,
       'maxBOF': 0
     }],
+    // allow things like __DEV__
     'no-underscore-dangle': 0,
     // no padding inside blocks
     'padded-blocks': ['error', { 'blocks': 'never' }],
+    // enforce a new line after any const or let if func / if follows
+    'padding-line-between-statements': ['error',
+      {
+        'blankLine': 'always',
+        'prev': ['const', 'let'],
+        'next': ['block-like', 'function', 'if']
+      },
+    ],
     // require or disallow use of semicolons instead of ASI
     'semi': [2, 'never'],
     // require or disallow space before function opening parenthesis

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,10 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-babel@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
+
 eslint-plugin-import@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"


### PR DESCRIPTION
No Story

`rent-js` didn't complain about missing `eslint-plugin-babel` because `rent-js-api` has it as a dependency.  This fixes it so it doesn't break.

Also, rearranged (alphabetical) rules.