### PR TITLE
adding no-multi-comp for stateless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# v1.0.1
-[Feature] Adds commitizen
-
-[Compare v1.0.0...v1.0.1](https://github.com/rentpath/eslint-config-rentpath/compare/v1.0.0...v1.1.0)
-
-# v1.0.0
-[Feature] Initial Setup & README
-
-[v0.0.1](https://github.com/rentpath/eslint-config-rentpath/tree/v1.0.0)

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ RentPath’s extensible shared config for [ESLint](http://eslint.org/)
 
 ## Installation
 ```javascript
-npm i --save-dev eslint eslint-config-rentpath
+# npm
+npm i --save-dev eslint @rentpath/eslint-config-rentpath
+
+# yarn
+yarn add eslint @rentpath/eslint-config-rentpath --dev
 ```
 
 ## Usage
 Add the following entry to your `.eslintrc`
 ```json
 {
-  "extends": "rentpath"
+  "extends": "@rentpath/eslint-config-rentpath"
 }
 ```
 
@@ -22,4 +26,4 @@ It's easiest to add a script to `package.json` to run linting; for example,
 }
 ```
 
-Then just `$ npm run lint`
+Then just `$ npm run lint` or `$ yarn lint`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/eslint-config-rentpath",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "RentPath’s extensible shared config for [ESLint](http://eslint.org/)",
   "main": "index.js",
   "repository": {
@@ -23,7 +23,7 @@
     "eslint-config-airbnb": "^15.1.0",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jest": "^20.0.3",
+    "eslint-plugin-jest": "^21.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.3.0"
   },

--- a/rules/react.js
+++ b/rules/react.js
@@ -16,6 +16,8 @@ module.exports = {
     'react/jsx-max-props-per-line': [1, { maximum: 3 }],
     // enforces proper names for jsx components
     'react/jsx-pascal-case': [2, { allowAllCaps: false }],
+    // disallow files from having more than one component at all
+    "react/no-multi-comp": [2, { "ignoreStateless": false }],
     // checks for proper casing and spelling on react syntax
     'react/no-typos': 2
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,9 +166,9 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jest@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz#ec15eba6ac0ab44a67ebf6e02672ca9d7e7cba29"
+eslint-plugin-jest@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.0.0.tgz#7ba4cab39b54dbafa1e3b2a73b42afccea325efe"
 
 eslint-plugin-jsx-a11y@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
No Story

- adding rule to not allow more than one stateless component per file
- cleaned up README
- upgraded jest plugin
- removing CHANGELOG and are relying on tags instead