### PR TITLE
Disable some rules

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -1,14 +1,19 @@
 module.exports = {
   rules: {
     // enforces no braces where they can be omitted
-    'arrow-body-style': [2, 'as-needed'],
+    // https://eslint.org/docs/rules/arrow-body-style
+    'arrow-body-style': 0,
     // require parens in arrow function arguments
-    'arrow-parens': [2, 'as-needed'],
+    // https://eslint.org/docs/rules/arrow-parens
+    'arrow-parens': 0,
     // suggest using arrow functions as callbacks
     'prefer-arrow-callback': 2,
     // allow file with no default export
     'import/prefer-default-export': 0,
     // ignore references to root directory
     'import/no-extraneous-dependencies': 0,
+    // allow import { default as Lib } from 'lib'
+    // overrides https://github.com/airbnb/javascript#modules--no-export-from-import
+    "import/no-named-default": 0
   }
 }


### PR DESCRIPTION
you are now allowed to write functions like 

```jsx
const foo = x => 'bar' // single arg without parens
// or
const foo = (x) => 'bar'  // single arg with parens
// or
const foo = (x) => { 
  return 'bar' 
} // no enforcement of arrow with implicit return
```

you are now allowed to write imports like 

```jsx
import { default as React } from 'react'
```