### PR TITLE
Enforce member expression indentation

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -11,7 +11,7 @@ module.exports = {
       'outerIIFEBody': 1,
       'ImportDeclaration': 'off',
       'SwitchCase': 1,
-      'MemberExpression': 'off',
+      'MemberExpression': 1,
       'FunctionDeclaration': {
         'parameters': 1,
         'body': 1


### PR DESCRIPTION
[Task](https://rentpath.atlassian.net/browse/INVP-440)

During a code review I realized our default eslint rules do not enforce indentation.

Flipping this rule on cleans up our existing code (almost all of the violations are in the e2e tests), and prevents it from getting messy in the future.